### PR TITLE
Remove throwable inaccuracy

### DIFF
--- a/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/gui/ConfigurationScreen.java
+++ b/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/gui/ConfigurationScreen.java
@@ -23,7 +23,7 @@ public class ConfigurationScreen extends Screen {
 		super(new TextComponent("Configuration"));
 	}
 
-	public static String[] optionsBoolean = new String[] { "B:tools:saveTickrate:INSERT", "B:ui:hideTickrateMessages:INSERT", "B:tools:showTickIndicator:INSERT", "B:tools:removePearlDelay:INSERT", "B:tools:noDamageUnbreaking:INSERT", "B:tools:removeThrowableInaccuracy"};
+	public static String[] optionsBoolean = new String[] { "B:tools:saveTickrate:INSERT", "B:ui:hideTickrateMessages:INSERT", "B:tools:showTickIndicator:INSERT", "B:tools:removePearlDelay:INSERT", "B:tools:noDamageUnbreaking:INSERT", "B:tools:removeThrowableInaccuracy:INSERT"};
 
 	public static String[] optionsInteger = new String[] { "I:hidden:explosionoptimization:INSERT" };
 

--- a/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/gui/ConfigurationScreen.java
+++ b/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/gui/ConfigurationScreen.java
@@ -23,7 +23,7 @@ public class ConfigurationScreen extends Screen {
 		super(new TextComponent("Configuration"));
 	}
 
-	public static String[] optionsBoolean = new String[] { "B:tools:saveTickrate:INSERT", "B:ui:hideTickrateMessages:INSERT", "B:tools:showTickIndicator:INSERT", "B:tools:removePearlDelay:INSERT", "B:tools:noDamageUnbreaking:INSERT"};
+	public static String[] optionsBoolean = new String[] { "B:tools:saveTickrate:INSERT", "B:ui:hideTickrateMessages:INSERT", "B:tools:showTickIndicator:INSERT", "B:tools:removePearlDelay:INSERT", "B:tools:noDamageUnbreaking:INSERT", "B:tools:removeThrowableInaccuracy"};
 
 	public static String[] optionsInteger = new String[] { "I:hidden:explosionoptimization:INSERT" };
 

--- a/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/mixin/patches/MixinInaccuracyPatch.java
+++ b/LoTAS-Fabric/src/main/java/de/pfannekuchen/lotas/mixin/patches/MixinInaccuracyPatch.java
@@ -1,0 +1,30 @@
+package de.pfannekuchen.lotas.mixin.patches;
+
+import de.pfannekuchen.lotas.core.utils.ConfigUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+/**
+ * Allows for removing the inaccuracy from throwables
+ * (is theoretically possible if the stars align on 3 gaussian randoms)
+ *
+ * @author CittyKat
+ */
+//#if MC>=11600
+//$$ @Mixin(net.minecraft.world.entity.projectile.Projectile.class)
+//#else
+@Mixin(net.minecraft.world.entity.projectile.ThrowableProjectile.class)
+//#endif
+public class MixinInaccuracyPatch {
+    @Redirect(method = "shoot(DDDFF)V", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextGaussian()D", remap = false))
+    private double redirect_internalShoot(Random random) {
+        if (ConfigUtils.getBoolean("tools", "removeThrowableInaccuracy")) {
+            return 0;
+        } else {
+            return random.nextGaussian();
+        }
+    }
+}

--- a/LoTAS-Fabric/src/main/resources/lotas.mixin.json
+++ b/LoTAS-Fabric/src/main/resources/lotas.mixin.json
@@ -6,7 +6,8 @@
     "mixins": [
     	"accessors.AccessorMobEntity",
     	"accessors.AccessorDimensionTypes",
-    	"accessors.AccessorLevelStorage"
+    	"accessors.AccessorLevelStorage",
+		"patches.MixinInaccuracyPatch"
     ],
     "client": [
     	"MixinMinecraftClient",

--- a/LoTAS-Forge/src/main/java/de/pfannekuchen/lotas/gui/GuiConfiguration.java
+++ b/LoTAS-Forge/src/main/java/de/pfannekuchen/lotas/gui/GuiConfiguration.java
@@ -18,7 +18,8 @@ public class GuiConfiguration extends GuiScreen {
 		"B:ui:hideTickrateMessages:INSERT",
 		"B:tools:showTickIndicator:INSERT",
 		"B:tools:removePearlDelay:INSERT",
-		"B:tools:noDamageUnbreaking:INSERT"
+		"B:tools:noDamageUnbreaking:INSERT",
+		"B:tools:removeThrowableInaccuracy:INSERT"
 	};
 	
 	public static String[] optionsInteger = new String[] {

--- a/LoTAS-Forge/src/main/java/de/pfannekuchen/lotas/mixin/patches/MixinInaccuracyPatch.java
+++ b/LoTAS-Forge/src/main/java/de/pfannekuchen/lotas/mixin/patches/MixinInaccuracyPatch.java
@@ -1,0 +1,32 @@
+package de.pfannekuchen.lotas.mixin.patches;
+
+import de.pfannekuchen.lotas.core.utils.ConfigUtils;
+import net.minecraft.entity.projectile.EntityThrowable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+/**
+ * Allows for removing the inaccuracy from throwables
+ * (is theoretically possible if the stars align on 3 gaussian randoms)
+ *
+ * @author CittyKat
+ */
+@Mixin(EntityThrowable.class)
+public abstract class MixinInaccuracyPatch {
+    //#if MC>=11200
+    @Redirect(method = "shoot(DDDFF)V", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextGaussian()D", remap = false))
+    //#else
+//$$ 	@Redirect(method = "setThrowableHeading", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextGaussian()D", remap = false))
+    //#endif
+    private double redirect_internalShoot(Random random) {
+        if (ConfigUtils.getBoolean("tools", "removeThrowableInaccuracy")) {
+            return 0;
+        } else {
+            return random.nextGaussian();
+        }
+    }
+}

--- a/LoTAS-Forge/src/main/resources/lotas.mixin.json
+++ b/LoTAS-Forge/src/main/resources/lotas.mixin.json
@@ -20,7 +20,8 @@
 		"patches.MixinServerPatch",
 		"patches.MixinEntityPlayerMPPatch",
 		"patches.MixinWorldProviderPatch",
-		"MixinMinecraftServer"
+		"MixinMinecraftServer",
+		"patches.MixinInaccuracyPatch"
     ],
     "client": [
     	"accessors.AccessorMinecraftClient",


### PR DESCRIPTION
Adds a config toggle to remove the inaccuracy on throwable projectiles, such as snowball, ender pearls, etc.